### PR TITLE
Add native popover support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Please note that this fork is not used on Stefan's page, nor is it maintained or
 
 Versions are incremented according to [semver](http://semver.org/).
 
+Also note that the version used in Aha! app is based on version 1.4.x, and has diverged from the original code is some significant ways.
+
 ## Links
 
 * [Online Demo](http://eternicode.github.io/bootstrap-datepicker/)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Please note that this fork is not used on Stefan's page, nor is it maintained or
 
 Versions are incremented according to [semver](http://semver.org/).
 
-Also note that the version used in Aha! app is based on version 1.4.x, and has diverged from the original code is some significant ways.
+Also note that the version used in Aha! app is based on version 1.4.x, and has diverged from the original code in some significant ways.
 
 ## Links
 

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -440,6 +440,7 @@
 			if (!this.isInline)
 				this.picker.appendTo(this.o.container);
 			this.place();
+			this.picker[0].showPopover();
 			this.picker.show();
 			this._attachSecondaryEvents();
 			this._trigger('show');
@@ -455,6 +456,7 @@
 			if (!this.picker.is(':visible'))
 				return this;
 			this.focusDate = null;
+			this.picker.get(0).hidePopover();
 			this.picker.hide().detach();
 			this._detachSecondaryEvents();
 			this.viewMode = this.o.startView;
@@ -1743,7 +1745,7 @@
 							'</tr>'+
 						'</tfoot>'
 	};
-	DPGlobal.template = '<div class="datepicker">'+
+	DPGlobal.template = '<div class="datepicker" popover="manual">'+
 							'<div class="datepicker-days">'+
 								'<table class=" table-condensed">'+
 									DPGlobal.headTemplate+

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aha-app/bootstrap-datepicker",
   "description": "A datepicker for twitter bootstrap forked from Stefan Petre's (of eyecon.ro), improvements by eternicode",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "license": "Apache-2.0",
   "main": "dist/js/@aha-app/bootstrap-datepicker.js",
   "keywords": [


### PR DESCRIPTION
## Summary

This PR adds native popover support to bootstrap-datepicker, which will allow us to remove the iripo listener in aha-app that currently forces datepickers to use popovers.

## Problem Being Solved

There's a subtle timing issue when bootstrap-datepicker manipulates its DOM:

1. After showing, the datepicker sometimes removes itself from the DOM, places itself in a document fragment, updates its content, then reattaches itself to the DOM.
2. When the datepicker is moved to the document fragment the popover API removes the datepicker from the top rendering layer (since fragments aren't part of the rendered DOM).
3. When this datepicker is moved _back_ to the DOM, while the inner contents of the datepicker have changed (which _will_ trigger a mutation observer), the _outer_ contents of the datepicker (which is what iripo is matching on) has not been altered, merely switched out and then back into the page. This results in iripo not detecting the re-attachment: since it is the same DOM node it already processed, as far as iripo is concerned nothing has changed.
4. Because iripo doesn't re-run its "in" callback, the datepicker's `showPopover()` isn't called again.
6. Result: the datepicker appears but isn't in the top render context.

## Solution

By implementing native popover support directly in bootstrap-datepicker, we can remove the iripo workaround and avoid this timing issue entirely.