### PR TITLE
A 19135 inline bootstrap datepicker and popover not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ Versions are incremented according to [semver](http://semver.org/).
 
 Also note that the version used in Aha! app is based on version 1.4.x, and has diverged from the original code in some significant ways.
 
+## Merging changes in GitHub
+In GitHub, always make sure your PR sets its `base_repository` to `aha-app/bootstrap-datepicker` (our version) rather than `uxsolutions/bootstrap-datepicker` (the original upstream).
+
 ## Links
 
 * [Online Demo](http://eternicode.github.io/bootstrap-datepicker/)

--- a/js/bootstrap-datepicker.js
+++ b/js/bootstrap-datepicker.js
@@ -440,7 +440,10 @@
 			if (!this.isInline)
 				this.picker.appendTo(this.o.container);
 			this.place();
-			this.picker[0].showPopover();
+			if (!this.isInline) {
+				this.picker.attr('popover', 'manual');
+				this.picker[0].showPopover();
+			}
 			this.picker.show();
 			this._attachSecondaryEvents();
 			this._trigger('show');
@@ -456,7 +459,9 @@
 			if (!this.picker.is(':visible'))
 				return this;
 			this.focusDate = null;
-			this.picker.get(0).hidePopover();
+			if (!this.picker.isInline) {
+				this.picker.get(0).hidePopover();
+			}
 			this.picker.hide().detach();
 			this._detachSecondaryEvents();
 			this.viewMode = this.o.startView;
@@ -1745,7 +1750,7 @@
 							'</tr>'+
 						'</tfoot>'
 	};
-	DPGlobal.template = '<div class="datepicker" popover="manual">'+
+	DPGlobal.template = '<div class="datepicker">'+
 							'<div class="datepicker-days">'+
 								'<table class=" table-condensed">'+
 									DPGlobal.headTemplate+

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aha-app/bootstrap-datepicker",
   "description": "A datepicker for twitter bootstrap forked from Stefan Petre's (of eyecon.ro), improvements by eternicode",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "license": "Apache-2.0",
   "main": "dist/js/@aha-app/bootstrap-datepicker.js",
   "keywords": [


### PR DESCRIPTION
Apparently there is a seldom used "inline" option for bootstrap datepicker. [A recent change](https://github.com/aha-app/bootstrap-datepicker/pull/5) to add popover support broke the inline option, as it is not popped in a menu at all.